### PR TITLE
Fixes an error from clipping small rasters

### DIFF
--- a/gdal_utils.py
+++ b/gdal_utils.py
@@ -151,7 +151,7 @@ def get_gdal_metadata(ds_path, is_raster, multiprocess_queue):
                 )
                 if len(bands) == 1:
                     ret["nodata"] = bands[0]
-
+                ret["dim"] = [dataset.RasterXSize, dataset.RasterYSize, len(bands)]
         if ret["driver"]:
             logger.debug("Identified dataset %s as %s", ds_path, ret["driver"])
         else:

--- a/gdal_utils.py
+++ b/gdal_utils.py
@@ -469,17 +469,15 @@ def convert_raster(
     options = clean_options({"creationOptions": creation_options, "format": driver})
     if not warp_params:
         warp_params = clean_options(
-            {
-                "outputType": band_type,
-                "dstAlpha": dst_alpha,
-                "srcSRS": src_srs,
-                "dstSRS": dst_srs,
-            }
+            {"outputType": band_type, "dstAlpha": dst_alpha, "srcSRS": src_srs, "dstSRS": dst_srs}
         )
     if not translate_params:
         translate_params = {}
     if boundary:
-        warp_params.update({"cutlineDSName": boundary, "cropToCutline": True})
+        # Conversion fails if trying to cut down very small files (i.e. 0x1 pixel error).
+        dims = list(map(sum, zip(*[get_meta(input_file)["dim"] for input_file in input_files]))) or [0, 0, 0]
+        if dims[0] > 100 and dims[1] > 100:
+            warp_params.update({"cutlineDSName": boundary, "cropToCutline": True})
     # Keep the name imagery which is used when seeding the geopackages.
     # Needed because arcpy can't change table names.
     if driver.lower() == "gpkg":

--- a/test_gdalutils.py
+++ b/test_gdalutils.py
@@ -416,9 +416,10 @@ class TestGdalUtils(TestCase):
         ]
         self.assertIsNone(get_band_statistics(in_file))
 
+    @patch("gdal_utils.get_meta")
     @patch("gdal_utils.get_dataset_names")
     @patch("gdal_utils.gdal")
-    def test_convert_raster(self, mock_gdal, mock_get_dataset_names):
+    def test_convert_raster(self, mock_gdal, mock_get_dataset_names, mock_get_meta):
         input_file = "/test/test.gpkg"
         output_file = "/test/test.tif"
         boundary = "/test/test.json"
@@ -434,11 +435,10 @@ class TestGdalUtils(TestCase):
             src_srs=srs,
             dst_srs=srs,
         )
+        mock_get_meta.assert_called_once_with(input_file)
         mock_gdal.Warp.assert_called_once_with(
             output_file,
             [input_file],
-            cropToCutline=True,
-            cutlineDSName=boundary,
             dstSRS=srs,
             format=driver,
             srcSRS=srs,
@@ -452,6 +452,7 @@ class TestGdalUtils(TestCase):
         mock_gdal.reset_mock()
         warp_params = {"warp": "params"}
         translate_params = {"translate": "params"}
+        mock_get_meta.return_value = {"dim": [200, 200, 1]}
         convert_raster(
             input_file,
             output_file,


### PR DESCRIPTION
To test try to convert a raster image which is only two pixels large, while also using a boundary (i.e. very low resolution data).  The code will ignore the boundary and just convert the file. 